### PR TITLE
FIXED: Entity relations for Referral and Loyalty

### DIFF
--- a/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/entities/LoyaltyEntity.java
+++ b/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/entities/LoyaltyEntity.java
@@ -23,9 +23,9 @@ public class LoyaltyEntity {
     @Column(name = "id", columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @JdbcTypeCode(BINARY)
-    @Column(name = "user_id", nullable = false, columnDefinition = "BINARY(16)", unique = true)
-    private UUID userId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", referencedColumnName = "user_id")
+    private UsersEntity user;
 
     @Column(name = "points", nullable = false)
     private Integer points;

--- a/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/entities/ReferralEntity.java
+++ b/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/entities/ReferralEntity.java
@@ -24,13 +24,13 @@ public class ReferralEntity {
     @Column(name = "id", columnDefinition = "BINARY(16)")
     private UUID id;
 
-    @JdbcTypeCode(BINARY)
-    @Column(name = "referrer_id", nullable = false, columnDefinition = "BINARY(16)")
-    private UUID referrerId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "referrer_id", referencedColumnName = "user_id")
+    private UsersEntity referrer;
 
-    @JdbcTypeCode(BINARY)
-    @Column(name = "referred_user_id", nullable = false, columnDefinition = "BINARY(16)")
-    private UUID referredUserId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "referred_user_id", referencedColumnName = "user_id")
+    private UsersEntity referredUser;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/repositories/LoyaltyRepository.java
+++ b/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/repositories/LoyaltyRepository.java
@@ -1,11 +1,12 @@
 package com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.repositories;
 
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.LoyaltyEntity;
+import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.UsersEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface LoyaltyRepository extends JpaRepository<LoyaltyEntity, UUID> {
-    Optional<LoyaltyEntity> findByUserId(UUID userId);
+    Optional<LoyaltyEntity> findByUser(UsersEntity user);
 }

--- a/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/services/LoyaltyService.java
+++ b/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/services/LoyaltyService.java
@@ -2,8 +2,10 @@ package com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense
 
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.dto.LoyaltyDTO;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.LoyaltyEntity;
+import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.UsersEntity;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.enums.LoyaltyTierEnum;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.repositories.LoyaltyRepository;
+import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.repositories.UsersRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -13,13 +15,18 @@ import java.util.UUID;
 public class LoyaltyService {
 
     private final LoyaltyRepository loyaltyRepository;
+    private final UsersRepository usersRepository;
 
-    public LoyaltyService(LoyaltyRepository loyaltyRepository) {
+    public LoyaltyService(LoyaltyRepository loyaltyRepository, UsersRepository usersRepository) {
         this.loyaltyRepository = loyaltyRepository;
+        this.usersRepository = usersRepository;
     }
 
     public LoyaltyDTO getLoyaltyStatus(UUID userId) {
-        Optional<LoyaltyEntity> loyaltyOpt = loyaltyRepository.findByUserId(userId);
+        UsersEntity user = usersRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Optional<LoyaltyEntity> loyaltyOpt = loyaltyRepository.findByUser(user);
 
         LoyaltyDTO dto = new LoyaltyDTO();
         dto.setUserId(userId);

--- a/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/services/ReferralService.java
+++ b/src/main/java/com/smart_shopping_list_expense_manager/java/smart_shopping_list_expense_manager/services/ReferralService.java
@@ -3,8 +3,10 @@ package com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.dto.ReferralDTO;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.dto.ReferralResponse;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.ReferralEntity;
+import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.entities.UsersEntity;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.enums.ReferralStatusEnum;
 import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.repositories.ReferralRepository;
+import com.smart_shopping_list_expense_manager.java.smart_shopping_list_expense_manager.repositories.UsersRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
@@ -13,16 +15,26 @@ import java.util.UUID;
 public class ReferralService {
 
     private final ReferralRepository referralRepository;
+    private final UsersRepository usersRepository;
 
-    public ReferralService(ReferralRepository referralRepository) {
+    public ReferralService(ReferralRepository referralRepository, UsersRepository usersRepository) {
         this.referralRepository = referralRepository;
+        this.usersRepository = usersRepository;
     }
+
 
     public ReferralResponse createReferral(ReferralDTO dto) {
         ReferralEntity referral = new ReferralEntity();
 
-        referral.setReferrerId(dto.getReferrerId());
-        referral.setReferredUserId(dto.getReferredUserId());
+        UsersEntity referrer = usersRepository.findById(dto.getReferrerId())
+                .orElseThrow(() -> new RuntimeException("Referrer not found"));
+
+        UsersEntity referred = usersRepository.findById(dto.getReferredUserId())
+                .orElseThrow(() -> new RuntimeException("Referred user not found"));
+
+        referral.setReferrer(referrer);
+        referral.setReferredUser(referred);
+
 
         // inicijalno postavljamo statu i nagradu ako vec nisu
         referral.setStatus(dto.getStatus() != null ? dto.getStatus() : ReferralStatusEnum.PENDING);


### PR DESCRIPTION
- Refactored `ReferralEntity`:
  - Replaced `referrerId` and `referredUserId` UUIDs with proper `UsersEntity` references
  - Added `@ManyToOne` relationships with `@JoinColumn`

- Refactored `LoyaltyEntity`:
  - Replaced `userId` UUID with `UsersEntity` reference
  - Added `@OneToOne` relationship with `@JoinColumn`

- Updated `ReferralService` and `LoyaltyService`:
  - Replaced direct UUID setting with user lookup via `UsersRepository`
  - Ensured entity relationships are correctly set during creation

- Updated `LoyaltyRepository`:
  - Added method `findByUser(UsersEntity user)`

